### PR TITLE
Custom 404 PyBaMM page

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,9 @@
+# Error 404: Page Not Found
+<!-- Custom 404 page for pybamm.org -->
+
+It looks like you've followed a broken link or entered a URL that doesn't exist on this site.
+
+:leftwards_arrow_with_hook: [Go back to PyBaMM Home](/)
+
+Seeing something you shouldn't? Please feel free to [contact us](/contact) and let us know what you were looking for, or open
+an issue on our [GitHub repository](https://www.github.com/pybamm-team/pybamm.org/issues).

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,3 +19,8 @@
   # optional, deploy the lighthouse report to a path under your site
   [plugins.inputs]
     output_path = "reports/lighthouse.html"
+
+[[redirects]]
+  status = 404
+  from = "/*"
+  to = "/404/"


### PR DESCRIPTION
Closes #11

Should link to `404.md` for all links that return status code 404 by directing via Netlify – doesn't work locally