### PR TITLE
`https://pybamm.org/slack/`

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,3 @@
 /benchmarks https://pybamm-team.github.io/pybamm-bench/ 301
+/slack https://join.slack.com/t/pybamm/shared_invite/zt-1xwnvkqrb-6ZKgB8yBU3zuzH91USdv_A 301
 /* /404/ 404

--- a/content/contact.md
+++ b/content/contact.md
@@ -15,7 +15,7 @@ discussions, please use the [GitHub discussions](https://github.com/pybamm-team/
 ### Slack
 
 For development discussions and to get help using PyBaMM, head over to our
-[Slack workspace](https://join.slack.com/t/pybamm/shared_invite/zt-1xwnvkqrb-6ZKgB8yBU3zuzH91USdv_A).
+[Slack workspace](/slack/).
 If the link doesn't work, you can email us at [pybamm@gmail.com](mailto:pybamm@gmail.com) for an invitation.
 
 ### General inquiries

--- a/content/gsoc/2024/_index.md
+++ b/content/gsoc/2024/_index.md
@@ -9,7 +9,7 @@ To find out more about PyBaMM, you can visit our website [pybamm.org](/) or read
 
 ## Getting started
 
-We mostly communicate via Slack, so you should start off by [joining our Slack workspace](https://www.pybamm.org/contact) and heading to the `#gsoc-main` channel.
+We mostly communicate via Slack, so you should start off by [joining our Slack workspace](/slack/) and heading to the `#gsoc-main` channel.
 
 A comprehensive set of [example notebooks](https://docs.pybamm.org/en/latest/source/examples/index.html) is available for becoming familiar with PyBaMM.
 Knowledge of battery physics or mathematical modeling is *not* required for any of the projects, but may be beneficial for some.

--- a/content/learn.md
+++ b/content/learn.md
@@ -40,4 +40,4 @@ We regularly hold PyBaMM workshops. You can find a list of the workshops we have
 
 ## Get help
 
-You can get help by posting questions on the PyBaMM Slack page or in [GitHub discussions](https://github.com/pybamm-team/PyBaMM/discussions). You can also get paid support from [Ionworks](https://ion-works.com/services).
+You can get help by posting questions on the [PyBaMM Slack channels](/slack/) or preferably in [GitHub discussions](https://github.com/pybamm-team/PyBaMM/discussions). You can also get paid support from [Ionworks](https://ion-works.com/services).

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,11 @@
   status = 301
 
 [[redirects]]
+  from = "/slack"
+  to = "https://join.slack.com/t/pybamm/shared_invite/zt-1xwnvkqrb-6ZKgB8yBU3zuzH91USdv_A"
+  status = 301
+
+[[redirects]]
   from = "/*"
   to = "/404/"
   status = 404


### PR DESCRIPTION
Add a custom redirect rule containing our shared invite link. Makes it easier to share it wherever needed