### PR TITLE
Move links to specific pages into a dropdown and improve footer

### DIFF
--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -156,3 +156,13 @@ a, a:hover, a:active {
 .title:not(.is-spaced) + .subtitle {
     margin-top: -0.2rem;
 }
+
+/* Navigation bar dropdown */
+
+.navbar.is-fresh .navbar-item.has-dropdown .navbar-link {
+    color: var(--colorPrimaryDark);
+}
+
+.navbar.is-fresh .navbar-item.has-dropdown .navbar-link:hover {
+    color: #4ca3c3
+}

--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -164,5 +164,5 @@ a, a:hover, a:active {
 }
 
 .navbar.is-fresh .navbar-item.has-dropdown .navbar-link:hover {
-    color: #4ca3c3
+    color: #4DABCF
 }

--- a/config.yaml
+++ b/config.yaml
@@ -64,10 +64,30 @@ params:
       # Should link to training and getting started pages
 
     - title: Community
-      url: /community/
+      sublinks:
+      - title: Contact
+        url: /community/
+      - title: Governance
+        url: /governance/
+      - title: Get Involved
+        url: /contribute/
+      - title: Roadmap
+        url: /roadmap/
+      - title: Google Summer of Code
+        url: /gsoc/
 
     - title: About Us
-      url: /about/
+      sublinks:
+      - title: About PyBaMM
+        url: /about/
+      - title: Ionworks
+        url: https://ion-works.com/
+        is_external: true
+      - title: PyBaMM on Twitter
+        url: https://twitter.com/pybamm_/
+        is_external: true
+      - title: PyBaMM Teams
+        url: /teams/
 
     - title: News
       url: /news/
@@ -127,12 +147,6 @@ params:
           - text: Documentation
             link: https://docs.pybamm.org/
 
-          - text: Citing PyBaMM
-            link: /publications/
-
-          - text: Ionworks
-            link: https://ion-works.com/
-
       column2:
         title: ""
         links:
@@ -140,22 +154,31 @@ params:
             link: /contact/
 
           - text: Get involved
-            link: https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md/
+            link: /contribute/
 
           - text: Training
             link: /training/
 
+          - text: Ionworks
+            link: https://ion-works.com/
+
           - text: News
             link: /news/
 
-          - text: Roadmap
-            link: https://github.com/pybamm-team/PyBaMM/wiki/Roadmap/
+      column3:
+        title: ""
+        links:
+          - text: About PyBaMM
+            link: /about/
+
+          - text: Citing PyBaMM
+            link: /publications/
 
           - text: Teams
             link: /teams/
 
-          # - text: Privacy
-          #   link: /privacy/
+          - text: Governance
+            link: /governance/
 
-      # column3:
-      #   links:
+          - text: Roadmap
+            link: https://github.com/pybamm-team/PyBaMM/wiki/Roadmap/

--- a/config.yaml
+++ b/config.yaml
@@ -67,8 +67,6 @@ params:
       sublinks:
       - title: Contact
         url: /community/
-      - title: Governance
-        url: /governance/
       - title: Get Involved
         url: /contribute/
       - title: Roadmap
@@ -86,6 +84,8 @@ params:
       - title: PyBaMM on Twitter
         url: https://twitter.com/pybamm_/
         is_external: true
+      - title: Governance
+        url: /governance/
       - title: PyBaMM Teams
         url: /teams/
 

--- a/content/contribute.md
+++ b/content/contribute.md
@@ -2,6 +2,6 @@
 title: Contribute to PyBaMM
 ---
 
-If you'd like to contribute to PyBaMM whether via reporting issues and bugs, updating the documentation, or adding new features (thanks!), please have a look at the [Contributing Guidelines](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md).
+If you'd like to contribute to PyBaMM whether via reporting issues and bugs, updating the documentation, or adding new features (thanks!), please have a look at the [Contributing Guidelines](https://docs.pybamm.org/en/latest/source/user_guide/contributing.html).
 
 {{< include-md "outline.md" >}}


### PR DESCRIPTION
Closes #81

I have added two dropdowns which should address the inclusion of all the internal pages we have, and included links to every page in the footer. This should resolve most if not all of the navigation issues one can face on a website where search functionality isn't available at the moment.