### PR TITLE
Remove links to deleted notebooks

### DIFF
--- a/content/learn.md
+++ b/content/learn.md
@@ -29,8 +29,6 @@ If you would like to get started with PyBaMM, you may go through the [Getting St
 - [Tutorial 7: Model options](https://colab.research.google.com/github/pybamm-team/PyBaMM/blob/main/docs/source/examples/notebooks/getting_started/tutorial-7-model-options.ipynb)
 - [Tutorial 8: Solver options](https://colab.research.google.com/github/pybamm-team/PyBaMM/blob/main/docs/source/examples/notebooks/getting_started/tutorial-8-solver-options.ipynb)
 - [Tutorial 9: Changing the mesh](https://colab.research.google.com/github/pybamm-team/PyBaMM/blob/main/docs/source/examples/notebooks/getting_started/tutorial-9-changing-the-mesh.ipynb)
-- [Tutorial 10: Creating a model](https://colab.research.google.com/github/pybamm-team/PyBaMM/blob/main/docs/source/examples/notebooks/getting_started/tutorial-10-creating-a-model.ipynb)
-- [Tutorial 11: Creating a submodel](https://colab.research.google.com/github/pybamm-team/PyBaMM/blob/main/docs/source/examples/notebooks/getting_started/tutorial-11-creating-a-submodel.ipynb)
 
 For more resources, please refer to the [Examples section](https://docs.pybamm.org/en/stable/source/examples/index.html) in the PyBaMM documentation.
 


### PR DESCRIPTION
The links to deleted notebooks in `learn.md` now have been removed. Related to https://github.com/pybamm-team/PyBaMM/pull/3750