### PR TITLE
Use GitHub Actions bot to push automated Teams page updates

### DIFF
--- a/.github/workflows/teams.yml
+++ b/.github/workflows/teams.yml
@@ -31,7 +31,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           # Commit details
-          commit-message: "[create-pull-request] update teams HTML files"
+          commit-message: "Automated update for the Teams page"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           # Pull request details
           branch: "create-pull-request/generate-teams"
           branch-suffix: timestamp


### PR DESCRIPTION
The workflow has been using my details to create commits in the automated PRs, and I wouldn't like to do so, so this PR configures the `peter-evans/create-pull-request@v7` action to commit using a bot instead