### PR TITLE
Add an "Open idea"

### DIFF
--- a/content/gsoc/2025/_index.md
+++ b/content/gsoc/2025/_index.md
@@ -3,12 +3,6 @@ title: PyBaMM GSoC 2025 Project Ideas
 summary: This page contains project ideas for PyBaMM's participation in the Google Summer of Code program in 2025. These projects are intended to be suitable for students who are new to PyBaMM or to open-source software development in general, and wish to work on a project that will be beneficial to PyBaMM and its community.
 ---
 
-{{< admonition note >}}
-
-We are planning on taking part in Google Summer of Code 2025. We will keep updating our project ideas and add potential ones here as soon as they are available. Stay tuned and keep following this page for updates!
-
-{{< /admonition >}}
-
 ## Adding type hints to PyBaMM models
 
 PyBaMM (Python Battery Mathematical Modelling) has evolved significantly since 2019 as a framework for battery modeling applications. While the focus on performance optimization has led to impressive speed improvements across PyBaMM and the time taken from conducting an experiment to its industrial impact, it has introduced complexity that can make code validation and maintenance challenging. This project aims to systematically introduce static typing to PyBaMM's codebase, particularly focusing on the `pybamm.models` component and surrounding areas, to enhance code safety and improve the developer experience.
@@ -52,25 +46,25 @@ The type system design will require particular attention to several key areas. T
 
 ### Potential mentors
 
-
-* [Saransh Chopra](https://Saransh-cpp.github.io/)
-* [Agriya Khetarpal](https://github.com/agriyakhetarpal/)
+- [Saransh Chopra](https://Saransh-cpp.github.io/)
+- [Agriya Khetarpal](https://github.com/agriyakhetarpal/)
 
 <!-- * [Valentin Sulzer](https://github.com/valentinsulzer)
 * [Robert Timms](https://github.com/rtimms)
 * [Arjun Verma](https://arjxnpy.vercel.app/)
 * [Ferran Brosa Planella](https://www.brosaplanella.xyz/) -->
 
+<hr>
+
 ## Adding a spirally wound geometry for thermal simulations in PyBaMM
 
 With the increasing demand for high-performance batteries, accurate thermal modeling of battery behavior is essential. A key challenge is the interaction between electrochemical and thermal dynamics in complicated battery geometries, which affects performance, safety, and lifespan. This project aims to develop a framework for the addition of coupled electrochemical-thermal simulations in PyBaMM in higher-dimensional geometries (e.g. cylindrical)
 
-This project aims to couple the electrochemical models already available in PyBaMM, such as the SPM or DFN, with a higher-dimensional thermal model.  As a proof of concept, the model will be used to simulate temperature distributions throughout the cell under different operating conditions.
+This project aims to couple the electrochemical models already available in PyBaMM, such as the SPM or DFN, with a higher-dimensional thermal model. As a proof of concept, the model will be used to simulate temperature distributions throughout the cell under different operating conditions.
 
 As a first step, a 3D thermal model will be implemented in PyBaMM with a constant heat source term. This will require adding new 3D meshes and spatial methods to PyBaMM (ideally by adding an existing 3D Finite Volume package as a dependency, such as Gmsh, Meshlib, Salome, etc). Next, this thermal model will be coupled with an electrochemical model, which will provide the heat source term. Finally, the coupling will be made two-way so that the lumped temperature from the 3D model feeds back into the electrochemical model.
 
 As a stretch goal, the project will explore the integration of 3D temperature profiles obtained from the spirally wound 3D thermal model back into the electrochemical model. This would enable feedback coupling, where the electrochemical model depends on the temperature distribution of the 3D model, providing a foundation for more complex coupling strategies in future research.
-
 
 ### Expected outcomes
 
@@ -92,3 +86,17 @@ The expected outcome of this study is a proof-of-concept 3D thermal model implem
 
 - [Robert Timms](https://github.com/rtimms)
 - [Nachiketh Grandhi](https://www.linkedin.com/in/nachiketh-grandhi-76393222a/)
+
+<hr>
+
+## Open project idea(s)
+
+We are also open to the inclusion of open project ideas for PyBaMM and candidates are encouraged to propose their own projects, if they feel at any time that our idea list does not currently cater to their interests and passions. If you have a project idea that you think would be beneficial to PyBaMM and its community, please feel free to reach out to us on our [Slack workspace](https://pybamm.org/slack/) in the `#gsoc-main` channel.
+
+The project should be validated with by getting in touch with potential mentors early, publicly, to ensure that its goals are realistic and within the scope of PyBaMM's roadmap, i.e., the project should also be beneficial to the PyBaMM community and should be able to be completed within the GSoC timeline.
+
+The requirements for the inclusion of said project must include:
+
+- A mentor within the PyBaMM maintainers team and the greater community who would be available and willing to support the project with code reviews, frequent meetings decided at a time with you during the coding period, and by offering general guidance and feedback within the scope of mentorship.
+- A clear project description, including the expected outcomes, the technical details, the desired skills, and the difficulty level of the project, similar to the project ideas listed on this page.
+- Proposed project length and timeline, including milestones and deliverables, which should be clearly defined and agreed upon by the mentor and the student (you). It should be either a **175-hour** or **350-hour** project, and not any other duration.

--- a/content/gsoc/2025/_index.md
+++ b/content/gsoc/2025/_index.md
@@ -93,7 +93,7 @@ The expected outcome of this study is a proof-of-concept 3D thermal model implem
 
 We are also open to the inclusion of open project ideas for PyBaMM and candidates are encouraged to propose their own projects, if they feel at any time that our idea list does not currently cater to their interests and passions. If you have a project idea that you think would be beneficial to PyBaMM and its community, please feel free to reach out to us on our [Slack workspace](https://pybamm.org/slack/) in the `#gsoc-main` channel.
 
-The project should be validated with by getting in touch with potential mentors early, publicly, to ensure that its goals are realistic and within the scope of PyBaMM's roadmap, i.e., the project should also be beneficial to the PyBaMM community and should be able to be completed within the GSoC timeline.
+The project should be validated by getting in touch with potential mentors early, publicly, to ensure that its goals are realistic and within the scope of PyBaMM's roadmap, i.e., the project should also be beneficial to the PyBaMM community and should be able to be completed within the GSoC timeline.
 
 The requirements for the inclusion of said project must include:
 


### PR DESCRIPTION
I realised that we never noted this explicitly in newer editions as the programme has went on, so this PR adds some placeholder text with the necessary format. Of course, such a project if proposed would be selected based on a mentor's availability and discretion. This makes external contributors aware that there is such a possibility.

P.S. I can't get the shortcut depth parameter to work at all, for some reason...