### PR TITLE
Update SPHT to tip-of-tree

### DIFF
--- a/content/gsoc/2023/_index.md
+++ b/content/gsoc/2023/_index.md
@@ -1,6 +1,7 @@
 ---
 title: PyBaMM GSoC 2023 Project Ideas
 summary: "Google Summer of Code 2023 with PyBaMM"
+shortcutDepth: 1
 ---
 
 # Projects

--- a/content/gsoc/2024/_index.md
+++ b/content/gsoc/2024/_index.md
@@ -1,6 +1,7 @@
 ---
 title: PyBaMM GSoC 2024 Project Ideas
 summary: This page contains project ideas for PyBaMM's participation in the Google Summer of Code program in 2024. These projects are intended to be suitable for students who are new to PyBaMM or to open-source software development in general, and wish to work on a project that will be beneficial to PyBaMM and its community.
+shortcutDepth: 1
 ---
 
 ## Migrate from `unittest` to `pytest` and improve PyBaMM's testing infrastructure

--- a/content/gsoc/2025/_index.md
+++ b/content/gsoc/2025/_index.md
@@ -1,6 +1,7 @@
 ---
 title: PyBaMM GSoC 2025 Project Ideas
 summary: This page contains project ideas for PyBaMM's participation in the Google Summer of Code program in 2025. These projects are intended to be suitable for students who are new to PyBaMM or to open-source software development in general, and wish to work on a project that will be beneficial to PyBaMM and its community.
+shortcutDepth: 1
 ---
 
 ## Adding type hints to PyBaMM models

--- a/content/gsod/_index.md
+++ b/content/gsod/_index.md
@@ -7,21 +7,21 @@ shortcutDepth: 1
 <!-- Note: the names of individual pages in folders should be marked with an
 underscore, i.e., _index.md to treat them as branched pages. -->
 
-# Document PyBaMM submodels
+## Document PyBaMM submodels
 
-## About the organisation
+### About the organisation
 
 PyBaMM (Python Battery Mathematical Modelling) is an open-source battery simulation package written in Python, whose mission is to accelerate battery modelling research by providing open-source tools for multi-institutional, interdisciplinary collaboration. Broadly, PyBaMM consists of (i) a framework for writing and solving systems of differential equations, (ii) a library of battery models and parameters, and (iii) specialised tools for simulating battery-specific experiments and visualising the results. Together, these enable flexible model definitions and fast battery simulations, allowing users to explore the effect of different battery designs and modelling assumptions under a variety of operating scenarios.
 
-## About the project
+### About the project
 
-### Problem
+#### Problem
 
 The battery models included in PyBaMM’s library consist of an innovative submodel structure allowing users to modify the physics they wish to include into their model, including such processes like degradation or particle mechanics. Ideally if a PyBaMM user or developer has developed new, novel battery submodels we wish to encourage them to include these within PyBaMM as a PR. However, so far we have only had limited success in encouraging people outside the core development team to contribute new battery models, and the obvious reason for this is that the documentation on the existing submodel structure is limited and there is no documentation on the process of integrating a new submodel.
 
 The goals of this project is to (a) document the existing submodule structure at a higher level than currently exists (the current documentation is limited to docstrings on individual classes), at a level suitable for new PyBaMM users who just wish to use the existing submodels, and (b) document the process for creating and publishing new PyBaMM models, either as a new submodel, or as a standalone model entry point.
 
-### Scope
+#### Scope
 
 This project has three goals, (a) document the existing submodel structure, (b) document the process for creating a new submodel, and (c) document how to publish a standalone model entry point.
 
@@ -33,14 +33,14 @@ The new documentation will be written in reStructuredText and incorporated into 
 
 Core PyBaMM developers [Martin Robinson](https://github.com/martinjrobins) and [Ferran Brosa Planella](https://github.com/brosaplanella) will onboard and then mentor the technical writer.
 
-### Measuring project's success
+#### Measuring the project's success
 
 Success measures for this project would be:
 Reducing the number of submodel questions on our GitHub discussion boards and allowing developers to simply point to existing documentation to answer these questions
 PRs adding or updating submodels from outside the current PyBaMM development team
 New model entry points from users outside the current development team
 
-### Timeline
+#### Timeline
 
 
 | Dates              | Action Items                                                                |
@@ -51,8 +51,7 @@ New model entry points from users outside the current development team
 | October - November | Review based on feedback and merge the user guides as PRs into the codebase |
 
 
-
-### Project budget
+#### Project budget
 
 
 | Budget Item      | Amount (USD)    | Notes                                                                    |
@@ -60,6 +59,6 @@ New model entry points from users outside the current development team
 | Technical writer | 10,000.00 | Design, write and publish new submodel and model entry point user-guides |
 
 
-### Additional information
+#### Additional information
 
 This project would be suitable for a technical writer familiar with mathematical modelling and working with Python and Sphinx. Any battery specific modelling experience is desirable, but could be picked up during the project as long as the writer has a general modelling background.


### PR DESCRIPTION
This pulls in changes from https://github.com/scientific-python/scientific-python-hugo-theme/pull/668. Specifically, this change makes the shortcuts in the secondary sidebar on branch bundles (`_index.md`-style pages) work again.

For instance: https://deploy-preview-265--pybamm-developer-preview.netlify.app/gsoc/2025/ now renders shortcuts that are not present on https://pybamm.org/gsoc/2025/.