### PR TITLE
Add link to Bluesky account

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,6 +117,9 @@ params:
       - link: https://twitter.com/pybamm_/
         icon: twitter
 
+      - link: https://bsky.app/profile/pybamm.org/
+        icon: bluesky
+
       - link: https://www.youtube.com/@pybamm_/
         icon: youtube
 


### PR DESCRIPTION
- Closes #254
- The submodule has been updated as scientific-python/scientific-python-hugo-theme#673 was needed and has now been merged