### PR TITLE
Updates and reorganisations for PyBaMM teams

### DIFF
--- a/content/teams.md
+++ b/content/teams.md
@@ -20,6 +20,10 @@ Contributions of any kind are welcome!
 
 {{< include-html "static/teams/maintainer-trainees.html" >}}
 
+{{< include-html "static/teams/gsoc-students.html" >}}
+
+{{< include-html "static/teams/past-gsoc-students.html" >}}
+
 {{< include-html "static/teams/contributors.html" >}}
 
 <!-- Use "nox -s teams" or alternatively run scripts/get_teams_info.py  -->

--- a/content/teams.md
+++ b/content/teams.md
@@ -26,5 +26,5 @@ Contributions of any kind are welcome!
 
 {{< include-html "static/teams/contributors.html" >}}
 
-<!-- Use "nox -s teams" or alternatively run scripts/get_teams_info.py  -->
+<!-- Use "nox -s teams" or alternatively run scripts/generate_teams.py  -->
 <!-- to regenerate the teams. -->

--- a/noxfile.py
+++ b/noxfile.py
@@ -88,4 +88,4 @@ def generate_teams(session):
 def lint(session):
     """Install 'pre-commit' and run linting on all files."""
     session.install("pre-commit-uv")
-    session.run("pre-commit", "run", "--all-files", "--show-diff-on-failure")
+    session.run("pre-commit", "run", "--all-files")

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,15 +77,15 @@ def clean_build(session):
         session.log('The "public" folder does not exist.')
 
 
-@nox.session(name="teams", venv_backend="virtualenv")
+@nox.session(name="teams", venv_backend="uv")
 def generate_teams(session):
     """Run 'generate_teams.py'."""
     session.install_and_run_script("scripts/generate_teams.py")
     session.notify("lint")
 
 
-@nox.session(name="lint", venv_backend="virtualenv")
+@nox.session(name="lint", venv_backend="uv")
 def lint(session):
     """Install 'pre-commit' and run linting on all files."""
-    session.install("pre-commit")
+    session.install("pre-commit-uv")
     session.run("pre-commit", "run", "--all-files", "--show-diff-on-failure")

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@ import shutil
 nox.options.reuse_existing_virtualenvs = True
 nox.options.default_venv_backend = "none"
 nox.options.sessions = ["themes", "html", "search", "serve-dev"]
+nox.needs_version = ">=2025.02.09"
 
 ERR_MSG = """there was an error running this command. Please ensure that npm/npx and the extended version of Hugo are installed and that the site configuration is valid."""
 
@@ -78,9 +79,8 @@ def clean_build(session):
 
 @nox.session(name="teams", venv_backend="virtualenv")
 def generate_teams(session):
-    """Install 'requests' and run 'generate_teams.py'."""
-    session.install("requests")
-    session.run("python", "scripts/generate_teams.py")
+    """Run 'generate_teams.py'."""
+    session.install_and_run_script("scripts/generate_teams.py")
     session.notify("lint")
 
 

--- a/scripts/generate_teams.py
+++ b/scripts/generate_teams.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "requests",
+# ]
+# ///
+
 # Description: This script generates the HTML for PyBaMM's maintainers and contributors
 # using the GitHub API.
 

--- a/scripts/generate_teams.py
+++ b/scripts/generate_teams.py
@@ -31,6 +31,8 @@ def read_file(file_path):
 PYBAMM_MAINTAINERS = read_file(DIR / "teams" / "MAINTAINERS")
 PYBAMM_EMERITUS_MAINTAINERS = read_file(DIR / "teams" / "EMERITUS-MAINTAINERS")
 PYBAMM_MAINTAINER_TRAINEES = read_file(DIR / "teams" / "MAINTAINER-TRAINEES")
+PYBAMM_GSOC_STUDENTS = read_file(DIR / "teams" / "GSOC-STUDENTS")
+PYBAMM_PAST_GSOC_STUDENTS = read_file(DIR / "teams" / "PAST-GSOC-STUDENTS")
 
 
 def query_contributors():
@@ -65,10 +67,12 @@ def get_contributors():
         "avatar_url": contributor["avatar_url"]
         }
         for contributor in PYBAMM_CONTRIBUTORS
-        # Exclude maintainers and maintainer trainees
+        # Exclude other teams
         if contributor["login"] not in PYBAMM_MAINTAINERS
         and contributor["login"] not in PYBAMM_EMERITUS_MAINTAINERS
         and contributor["login"] not in PYBAMM_MAINTAINER_TRAINEES
+        and contributor["login"] not in PYBAMM_GSOC_STUDENTS
+        and contributor["login"] not in PYBAMM_PAST_GSOC_STUDENTS
         # Exclude all bots (pre-commit-ci, allcontributors, dependabot, et cetera)
         and not contributor["login"].endswith("[bot]")
     ]
@@ -129,8 +133,39 @@ def get_maintainer_trainees():
         for maintainer_trainee in maintainer_trainees
     ]
 
+
+def get_gsoc_students():
+    """
+    Get "login", "html_url", and "avatar_url" fields for each GSoC student.
+    """
+    return [
+        {
+        "login": contributor["login"],
+        "html_url": contributor["html_url"],
+        "avatar_url": contributor["avatar_url"],
+        }
+        for contributor in PYBAMM_CONTRIBUTORS
+        if contributor["login"] in PYBAMM_GSOC_STUDENTS
+    ]
+
+
+def get_past_gsoc_students():
+    """
+    Get "login", "html_url", and "avatar_url" fields for each past GSoC student.
+    """
+    return [
+        {
+        "login": contributor["login"],
+        "html_url": contributor["html_url"],
+        "avatar_url": contributor["avatar_url"],
+        }
+        for contributor in PYBAMM_CONTRIBUTORS
+        if contributor["login"] in PYBAMM_PAST_GSOC_STUDENTS
+    ]
+
+
 # The team name can be either of the following:
-# emeritus maintainers, maintainers, maintainer trainees, or contributors
+# emeritus maintainers, maintainers, maintainer trainees, current GSoC students, past GSoC students, and contributors
 team_template = string.Template(
 """
 <div class="team">
@@ -214,6 +249,46 @@ with open("static/teams/maintainer-trainees.html", "w") as file:
                         name=maintainer_trainee["login"],
                     )
                     for maintainer_trainee in get_maintainer_trainees()
+                ]
+            ),
+        )
+    )
+
+# Generate the HTML in static/teams/gsoc-students.html, overwriting as necessary
+print("Generating GSoC students...")
+print("Current GSoC students are:", PYBAMM_GSOC_STUDENTS)
+with open("static/teams/gsoc-students.html", "w") as file:
+    file.write(
+        team_template.substitute(
+            team_name="Current Google Summer of Code students",
+            members="".join(
+                [
+                    member_template.substitute(
+                        url=contributor["html_url"],
+                        avatarUrl=contributor["avatar_url"],
+                        name=contributor["login"],
+                    )
+                    for contributor in get_gsoc_students()
+                ]
+            ),
+        )
+    )
+
+# Generate the HTML in static/teams/past-gsoc-students.html, overwriting as necessary
+print("Generating past GSoC students...")
+print("Past GSoC students are:", PYBAMM_PAST_GSOC_STUDENTS)
+with open("static/teams/past-gsoc-students.html", "w") as file:
+    file.write(
+        team_template.substitute(
+            team_name="Past Google Summer of Code students",
+            members="".join(
+                [
+                    member_template.substitute(
+                        url=contributor["html_url"],
+                        avatarUrl=contributor["avatar_url"],
+                        name=contributor["login"],
+                    )
+                    for contributor in get_past_gsoc_students()
                 ]
             ),
         )

--- a/scripts/generate_teams.py
+++ b/scripts/generate_teams.py
@@ -35,14 +35,21 @@ PYBAMM_MAINTAINER_TRAINEES = read_file(DIR / "teams" / "MAINTAINER-TRAINEES")
 
 def query_contributors():
     # Get the list of contributors from the endpoint iteratively until we get
-    url = "https://raw.githubusercontent.com/pybamm-team/PyBaMM/develop/.all-contributorsrc"
-    contributors = requests.get(url).json()
-    for obj in contributors["contributors"]:
-        # Check if the dictionary has the key 'profile'
-        if 'profile' in obj:
-            # Replace the key 'profile' with 'website'
-            obj['html_url'] = obj.pop('profile')
-    return contributors["contributors"]
+    # an empty response
+    contributors_list = []
+    page = 1
+    while True:
+        contributors = requests.get(
+            f"https://api.github.com/repos/pybamm-team/pybamm/contributors?per_page=100&page={page}"
+        ).json()
+        if contributors == []:
+            break
+        else:
+            contributors_list += contributors
+            page += 1
+    return contributors_list
+
+
 PYBAMM_CONTRIBUTORS = query_contributors()
 
 
@@ -53,7 +60,7 @@ def get_contributors():
     """
     return [
         {
-        "login": contributor["name"],
+        "login": contributor["login"],
         "html_url": contributor["html_url"],
         "avatar_url": contributor["avatar_url"]
         }
@@ -74,7 +81,7 @@ def get_maintainers():
     """
     return [
         {
-        "login": maintainer["name"],
+        "login": maintainer["login"],
         "html_url": maintainer["html_url"],
         "avatar_url": maintainer["avatar_url"],
         }
@@ -91,7 +98,7 @@ def get_emeritus_maintainers():
     """
     return [
         {
-        "login": emeritus_maintainer["name"],
+        "login": emeritus_maintainer["login"],
         "html_url": emeritus_maintainer["html_url"],
         "avatar_url": emeritus_maintainer["avatar_url"],
         }
@@ -115,7 +122,7 @@ def get_maintainer_trainees():
 
     return [
         {
-        "login": maintainer_trainee["name"],
+        "login": maintainer_trainee["login"],
         "html_url": maintainer_trainee["html_url"],
         "avatar_url": maintainer_trainee["avatar_url"],
         }

--- a/scripts/generate_teams.py
+++ b/scripts/generate_teams.py
@@ -169,7 +169,7 @@ def get_past_gsoc_students():
 team_template = string.Template(
 """
 <div class="team">
-    <h3 id="${team_name}"class="name title">
+    <h2 id="${team_name}"class="name title">
     ${team_name}
     </h3>
         <div class="sd-container-fluid sd-mb-4 false">

--- a/static/teams/contributors.html
+++ b/static/teams/contributors.html
@@ -1,6 +1,6 @@
 
 <div class="team">
-    <h3 id="Contributors"class="name title">
+    <h2 id="Contributors"class="name title">
     Contributors
     </h3>
         <div class="sd-container-fluid sd-mb-4 false">
@@ -8,240 +8,10 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars1.githubusercontent.com/u/6095790?v=4" alt="Avatar of Diego"/>
-                    Diego
+                <img src="https://avatars.githubusercontent.com/u/98161205?v=4" alt="Avatar of jsbrittain"/>
+                    jsbrittain
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/dalonsoa"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars2.githubusercontent.com/u/64426781?v=4" alt="Avatar of felipe-salinas"/>
-                    felipe-salinas
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/felipe-salinas"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars3.githubusercontent.com/u/57151989?v=4" alt="Avatar of suhaklee"/>
-                    suhaklee
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/suhaklee"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars0.githubusercontent.com/u/6379429?v=4" alt="Avatar of viviantran27"/>
-                    viviantran27
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/viviantran27"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars0.githubusercontent.com/u/60714526?v=4" alt="Avatar of gyouhoc"/>
-                    gyouhoc
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/gyouhoc"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars0.githubusercontent.com/u/62429912?v=4" alt="Avatar of Yannick Kuhn"/>
-                    Yannick Kuhn
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/YannickNoelStephanKuhn"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars2.githubusercontent.com/u/39409226?v=4" alt="Avatar of Jacqueline Edge"/>
-                    Jacqueline Edge
-                </div>
-            <a class="sd-stretched-link" href="http://batterymodel.co.uk"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars3.githubusercontent.com/u/3770306?v=4" alt="Avatar of Fergus Cooper"/>
-                    Fergus Cooper
-                </div>
-            <a class="sd-stretched-link" href="https://www.rse.ox.ac.uk/"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars1.githubusercontent.com/u/28925818?v=4" alt="Avatar of jonchapman1"/>
-                    jonchapman1
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/jonchapman1"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars3.githubusercontent.com/u/44977104?v=4" alt="Avatar of Colin Please"/>
-                    Colin Please
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/colinplease"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/92099819?v=4" alt="Avatar of cwmonroe"/>
-                    cwmonroe
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/cwmonroe"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/18349157?v=4" alt="Avatar of Greg"/>
-                    Greg
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/gjo97"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars2.githubusercontent.com/u/42166506?v=4" alt="Avatar of Faraday Institution"/>
-                    Faraday Institution
-                </div>
-            <a class="sd-stretched-link" href="https://faraday.ac.uk"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars3.githubusercontent.com/u/1999462?v=4" alt="Avatar of Alexander Bessman"/>
-                    Alexander Bessman
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/bessman"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars1.githubusercontent.com/u/19659095?v=4" alt="Avatar of dalbamont"/>
-                    dalbamont
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/dalbamont"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars1.githubusercontent.com/u/34894671?v=4" alt="Avatar of Anand Mohan Yadav"/>
-                    Anand Mohan Yadav
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/anandmy"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars1.githubusercontent.com/u/41424174?v=4" alt="Avatar of WEILONG AI"/>
-                    WEILONG AI
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/weilongai"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars2.githubusercontent.com/u/35983543?v=4" alt="Avatar of lonnbornj"/>
-                    lonnbornj
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/lonnbornj"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/10965193?v=4" alt="Avatar of David Straub"/>
-                    David Straub
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/DavidMStraub"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/37576773?v=4" alt="Avatar of maurosgroi"/>
-                    maurosgroi
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/maurosgroi"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/77078706?v=4" alt="Avatar of Amarjit Singh Gaba"/>
-                    Amarjit Singh Gaba
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/asinghgaba"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/78538806?v=4" alt="Avatar of KennethNwanoro"/>
-                    KennethNwanoro
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/KennethNwanoro"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/65511923?v=4" alt="Avatar of Ali Hussain Umar Bhatti"/>
-                    Ali Hussain Umar Bhatti
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/alibh95"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/81125862?v=4" alt="Avatar of Leshinka Molel"/>
-                    Leshinka Molel
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/molel-gt"></a>
+            <a class="sd-stretched-link" href="https://github.com/jsbrittain"></a>
             </div>
         </div>
 
@@ -258,148 +28,38 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/13491954?v=4" alt="Avatar of Chuck Liu"/>
-                    Chuck Liu
+                <img src="https://avatars.githubusercontent.com/u/41424174?v=4" alt="Avatar of weilongai"/>
+                    weilongai
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/chuckliu1979"></a>
+            <a class="sd-stretched-link" href="https://github.com/weilongai"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/88316576?v=4" alt="Avatar of partben"/>
-                    partben
+                <img src="https://avatars.githubusercontent.com/u/55396775?v=4" alt="Avatar of pipliggins"/>
+                    pipliggins
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/partben"></a>
+            <a class="sd-stretched-link" href="https://github.com/pipliggins"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/6828967?v=4" alt="Avatar of Gavin Wiggins"/>
-                    Gavin Wiggins
+                <img src="https://avatars.githubusercontent.com/u/6095790?v=4" alt="Avatar of dalonsoa"/>
+                    dalonsoa
                 </div>
-            <a class="sd-stretched-link" href="https://gavinw.me"></a>
+            <a class="sd-stretched-link" href="https://github.com/dalonsoa"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/91852142?v=4" alt="Avatar of Dion Wilde"/>
-                    Dion Wilde
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/dion-w"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/48386220?v=4" alt="Avatar of Elias Hohl"/>
-                    Elias Hohl
-                </div>
-            <a class="sd-stretched-link" href="https://www.ehtec.co"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/93784399?v=4" alt="Avatar of KAschad"/>
-                    KAschad
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/KAschad"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/92637595?v=4" alt="Avatar of Vaibhav-Chopra-GT"/>
-                    Vaibhav-Chopra-GT
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/Vaibhav-Chopra-GT"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/54084289?v=4" alt="Avatar of bardsleypt"/>
-                    bardsleypt
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/bardsleypt"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/56122552?v=4" alt="Avatar of ndrewwang"/>
-                    ndrewwang
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/ndrewwang"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/58085966?v=4" alt="Avatar of MichaPhilipp"/>
-                    MichaPhilipp
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/MichaPhilipp"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/5857298?v=4" alt="Avatar of Alex Wadell"/>
-                    Alex Wadell
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/awadell1"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/112731474?v=4" alt="Avatar of iatzak"/>
-                    iatzak
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/iatzak"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/72691866?v=4" alt="Avatar of Ankit Kumar"/>
-                    Ankit Kumar
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/ayeankit"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/31622972?v=4" alt="Avatar of Aniket Singh Rawat"/>
-                    Aniket Singh Rawat
-                </div>
-            <a class="sd-stretched-link" href="https://aniketsinghrawat.vercel.app/"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/83979298?v=4" alt="Avatar of Jerom Palimattom Tom"/>
-                    Jerom Palimattom Tom
+                <img src="https://avatars.githubusercontent.com/u/83979298?v=4" alt="Avatar of jeromtom"/>
+                    jeromtom
                 </div>
             <a class="sd-stretched-link" href="https://github.com/jeromtom"></a>
             </div>
@@ -408,240 +68,20 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/55357039?v=4" alt="Avatar of Brady Planden"/>
-                    Brady Planden
+                <img src="https://avatars.githubusercontent.com/u/78538806?v=4" alt="Avatar of KennethNwanoro"/>
+                    KennethNwanoro
                 </div>
-            <a class="sd-stretched-link" href="http://bradyplanden.github.io"></a>
+            <a class="sd-stretched-link" href="https://github.com/KennethNwanoro"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/98161205?v=4" alt="Avatar of jsbrittain"/>
-                    jsbrittain
+                <img src="https://avatars.githubusercontent.com/u/64426781?v=4" alt="Avatar of felipe-salinas"/>
+                    felipe-salinas
                 </div>
-            <a class="sd-stretched-link" href="http://www.jsbrittain.com/"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/75906533?v=4" alt="Avatar of CHEN ZHAO"/>
-                    CHEN ZHAO
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/chenzhao-py"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/91731499?v=4" alt="Avatar of darryl-ad"/>
-                    darryl-ad
-                </div>
-            <a class="sd-stretched-link" href="https://www.aboutenergy.io/"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/133691040?v=4" alt="Avatar of julian-evers"/>
-                    julian-evers
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/julian-evers"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/633873?v=4" alt="Avatar of Jason Siegel"/>
-                    Jason Siegel
-                </div>
-            <a class="sd-stretched-link" href="https://batterycontrolgroup.engin.umich.edu/"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/101814207?v=4" alt="Avatar of Tom Maull"/>
-                    Tom Maull
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/tommaull"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/116663050?v=4" alt="Avatar of ejfdickinson"/>
-                    ejfdickinson
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/ejfdickinson"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/22030806?v=4" alt="Avatar of bobonice"/>
-                    bobonice
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/bobonice"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/26191851?v=4" alt="Avatar of Andrés Ignacio Torres"/>
-                    Andrés Ignacio Torres
-                </div>
-            <a class="sd-stretched-link" href="https://aitorres.com"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/77234005?v=4" alt="Avatar of Agnik Bakshi"/>
-                    Agnik Bakshi
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/Agnik7"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/127507466?v=4" alt="Avatar of chmabaur"/>
-                    chmabaur
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/chmabaur"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/91185083?v=4" alt="Avatar of Abhishek Chaudhari"/>
-                    Abhishek Chaudhari
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/AbhishekChaudharii"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/32607282?v=4" alt="Avatar of Shubham Bhardwaj"/>
-                    Shubham Bhardwaj
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/shubhambhar007"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/28939653?v=4" alt="Avatar of Jonathan Lauber"/>
-                    Jonathan Lauber
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/jlauber18"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/99216956?v=4" alt="Avatar of Pradyot Ranjan"/>
-                    Pradyot Ranjan
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/prady0t"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/53944452?v=4" alt="Avatar of XuboGU"/>
-                    XuboGU
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/XuboGU"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/121183876?v=4" alt="Avatar of Ankit Meda"/>
-                    Ankit Meda
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/cringeyburger"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/38499721?v=4" alt="Avatar of Alessio Bugetti"/>
-                    Alessio Bugetti
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/AlessioBugetti"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/68015525?v=4" alt="Avatar of AKHIL SHARMA"/>
-                    AKHIL SHARMA
-                </div>
-            <a class="sd-stretched-link" href="http://akhilsharma.info"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/75773763?v=4" alt="Avatar of Harshvir Sandhu"/>
-                    Harshvir Sandhu
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/HarshvirSandhu"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/44714920?v=4" alt="Avatar of Lorenzo"/>
-                    Lorenzo
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/lorenzofavaro"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/143705453?v=4" alt="Avatar of AndyLiuElysia"/>
-                    AndyLiuElysia
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/AndyLiuElysia"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/143798726?v=4" alt="Avatar of Hongmeiqi"/>
-                    Hongmeiqi
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/Hongmeiqi"></a>
+            <a class="sd-stretched-link" href="https://github.com/felipe-salinas"></a>
             </div>
         </div>
 
@@ -658,70 +98,230 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/119055274?v=4" alt="Avatar of Abhi ram"/>
-                    Abhi ram
+                <img src="https://avatars.githubusercontent.com/u/57276779?v=4" alt="Avatar of anoushka2000"/>
+                    anoushka2000
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/abhicodes369"></a>
+            <a class="sd-stretched-link" href="https://github.com/anoushka2000"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/29599800?v=4" alt="Avatar of Ivan Korotkin"/>
-                    Ivan Korotkin
+                <img src="https://avatars.githubusercontent.com/u/77078706?v=4" alt="Avatar of asinghgaba"/>
+                    asinghgaba
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/ikorotkin"></a>
+            <a class="sd-stretched-link" href="https://github.com/asinghgaba"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/52504160?v=4" alt="Avatar of Santhosh"/>
-                    Santhosh
+                <img src="https://avatars.githubusercontent.com/u/633873?v=4" alt="Avatar of js1tr3"/>
+                    js1tr3
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/santacodes"></a>
+            <a class="sd-stretched-link" href="https://github.com/js1tr3"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/173074476?v=4" alt="Avatar of Ubham16"/>
-                    Ubham16
+                <img src="https://avatars.githubusercontent.com/u/55357039?v=4" alt="Avatar of BradyPlanden"/>
+                    BradyPlanden
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/Ubham16"></a>
+            <a class="sd-stretched-link" href="https://github.com/BradyPlanden"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/30574522?v=4" alt="Avatar of Mehrdad Babazadeh"/>
-                    Mehrdad Babazadeh
+                <img src="https://avatars.githubusercontent.com/u/91852142?v=4" alt="Avatar of dion-w"/>
+                    dion-w
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/MehrdadBabazadeh"></a>
+            <a class="sd-stretched-link" href="https://github.com/dion-w"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/55396775?v=4" alt="Avatar of Pip Liggins"/>
-                    Pip Liggins
+                <img src="https://avatars.githubusercontent.com/u/5857298?v=4" alt="Avatar of awadell1"/>
+                    awadell1
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/pipliggins"></a>
+            <a class="sd-stretched-link" href="https://github.com/awadell1"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/143182673?v=4" alt="Avatar of Medha Bhardwaj"/>
-                    Medha Bhardwaj
+                <img src="https://avatars.githubusercontent.com/u/57151989?v=4" alt="Avatar of suhaklee"/>
+                    suhaklee
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/medha-14"></a>
+            <a class="sd-stretched-link" href="https://github.com/suhaklee"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/65511923?v=4" alt="Avatar of alibh95"/>
+                    alibh95
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/alibh95"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/38499721?v=4" alt="Avatar of AlessioBugetti"/>
+                    AlessioBugetti
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/AlessioBugetti"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/35983543?v=4" alt="Avatar of lonnbornj"/>
+                    lonnbornj
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/lonnbornj"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/91185083?v=4" alt="Avatar of AbhishekChaudharii"/>
+                    AbhishekChaudharii
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/AbhishekChaudharii"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/3770306?v=4" alt="Avatar of fcooper8472"/>
+                    fcooper8472
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/fcooper8472"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/81125862?v=4" alt="Avatar of molel-gt"/>
+                    molel-gt
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/molel-gt"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/6379429?v=4" alt="Avatar of viviantran27"/>
+                    viviantran27
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/viviantran27"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/77234005?v=4" alt="Avatar of Agnik7"/>
+                    Agnik7
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/Agnik7"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/112749383?v=4" alt="Avatar of akhilender-bongirwar"/>
+                    akhilender-bongirwar
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/akhilender-bongirwar"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/19659095?v=4" alt="Avatar of dalbamont"/>
+                    dalbamont
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/dalbamont"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/32607282?v=4" alt="Avatar of shubhambhar007"/>
+                    shubhambhar007
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/shubhambhar007"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/60714526?v=4" alt="Avatar of gyouhoc"/>
+                    gyouhoc
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/gyouhoc"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/113838908?v=4" alt="Avatar of Rjchauhan18"/>
+                    Rjchauhan18
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/Rjchauhan18"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/62429912?v=4" alt="Avatar of YannickNoelStephanKuhn"/>
+                    YannickNoelStephanKuhn
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/YannickNoelStephanKuhn"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/6828967?v=4" alt="Avatar of wigging"/>
+                    wigging
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/wigging"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/112731474?v=4" alt="Avatar of iatzak"/>
+                    iatzak
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/iatzak"></a>
             </div>
         </div>
 
@@ -738,30 +338,60 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/123981577?v=4" alt="Avatar of isaacbasil"/>
-                    isaacbasil
+                <img src="https://avatars.githubusercontent.com/u/112854574?v=4" alt="Avatar of vidipsingh"/>
+                    vidipsingh
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/isaacbasil"></a>
+            <a class="sd-stretched-link" href="https://github.com/vidipsingh"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/55912083?v=4" alt="Avatar of Andrew Esterson"/>
-                    Andrew Esterson
+                <img src="https://avatars.githubusercontent.com/u/48386220?v=4" alt="Avatar of ehtec"/>
+                    ehtec
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/AndEsterson"></a>
+            <a class="sd-stretched-link" href="https://github.com/ehtec"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/153092659?v=4" alt="Avatar of ahamed24"/>
-                    ahamed24
+                <img src="https://avatars.githubusercontent.com/u/211978538?v=4" alt="Avatar of discolotus"/>
+                    discolotus
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/ahamed24"></a>
+            <a class="sd-stretched-link" href="https://github.com/discolotus"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/101407290?v=4" alt="Avatar of mbonkile"/>
+                    mbonkile
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/mbonkile"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/88316576?v=4" alt="Avatar of partben"/>
+                    partben
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/partben"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/101814207?v=4" alt="Avatar of tommaull"/>
+                    tommaull
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/tommaull"></a>
             </div>
         </div>
 
@@ -778,10 +408,90 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/112854574?v=4" alt="Avatar of Vidip Singh"/>
-                    Vidip Singh
+                <img src="https://avatars.githubusercontent.com/u/91731499?v=4" alt="Avatar of darryl-ad"/>
+                    darryl-ad
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/vidipsingh"></a>
+            <a class="sd-stretched-link" href="https://github.com/darryl-ad"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/31622972?v=4" alt="Avatar of dikwickley"/>
+                    dikwickley
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/dikwickley"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/94122883?v=4" alt="Avatar of R-Yash"/>
+                    R-Yash
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/R-Yash"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/44714920?v=4" alt="Avatar of lorenzofavaro"/>
+                    lorenzofavaro
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/lorenzofavaro"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/51965251?v=4" alt="Avatar of d-cogswell"/>
+                    d-cogswell
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/d-cogswell"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/86532127?v=4" alt="Avatar of parthxtripathi"/>
+                    parthxtripathi
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/parthxtripathi"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/28925818?v=4" alt="Avatar of jonchapman1"/>
+                    jonchapman1
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/jonchapman1"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/55912083?v=4" alt="Avatar of AndEsterson"/>
+                    AndEsterson
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/AndEsterson"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/139366626?v=4" alt="Avatar of Jiabin-Wang"/>
+                    Jiabin-Wang
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/Jiabin-Wang"></a>
             </div>
         </div>
 
@@ -798,18 +508,78 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/51965251?v=4" alt="Avatar of Dan Cogswell"/>
-                    Dan Cogswell
+                <img src="https://avatars.githubusercontent.com/u/127507466?v=4" alt="Avatar of chmabaur"/>
+                    chmabaur
                 </div>
-            <a class="sd-stretched-link" href="https://dancogswell.com"></a>
+            <a class="sd-stretched-link" href="https://github.com/chmabaur"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/139000226?v=4" alt="Avatar of Pratham Hole"/>
-                    Pratham Hole
+                <img src="https://avatars.githubusercontent.com/u/57339960?v=4" alt="Avatar of 1836005678"/>
+                    1836005678
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/1836005678"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/68015525?v=4" alt="Avatar of Akhil-Sharma30"/>
+                    Akhil-Sharma30
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/Akhil-Sharma30"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/10965193?v=4" alt="Avatar of DavidMStraub"/>
+                    DavidMStraub
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/DavidMStraub"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/72691866?v=4" alt="Avatar of ayeankit"/>
+                    ayeankit
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/ayeankit"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/143705453?v=4" alt="Avatar of AndyLiuElysia"/>
+                    AndyLiuElysia
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/AndyLiuElysia"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/13301031?v=4" alt="Avatar of ezpzbz"/>
+                    ezpzbz
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/ezpzbz"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/139000226?v=4" alt="Avatar of Prtm2110"/>
+                    Prtm2110
                 </div>
             <a class="sd-stretched-link" href="https://github.com/Prtm2110"></a>
             </div>
@@ -818,10 +588,260 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/152909047?v=4" alt="Avatar of JC_005"/>
-                    JC_005
+                <img src="https://avatars.githubusercontent.com/u/40054659?v=4" alt="Avatar of raghuramshankar"/>
+                    raghuramshankar
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/raghuramshankar"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/56045049?v=4" alt="Avatar of soma2000-lang"/>
+                    soma2000-lang
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/soma2000-lang"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/138931832?v=4" alt="Avatar of tanishac25"/>
+                    tanishac25
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/tanishac25"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/973268?v=4" alt="Avatar of kinnala"/>
+                    kinnala
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/kinnala"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/173074476?v=4" alt="Avatar of Ubham16"/>
+                    Ubham16
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/Ubham16"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/53944452?v=4" alt="Avatar of XuboGU"/>
+                    XuboGU
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/XuboGU"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/153092659?v=4" alt="Avatar of ahamed24"/>
+                    ahamed24
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/ahamed24"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/22030806?v=4" alt="Avatar of bobonice"/>
+                    bobonice
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/bobonice"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/148784177?v=4" alt="Avatar of buddhiwisr"/>
+                    buddhiwisr
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/buddhiwisr"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/123981577?v=4" alt="Avatar of isaacbasil"/>
+                    isaacbasil
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/isaacbasil"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/56122552?v=4" alt="Avatar of ndrewwang"/>
+                    ndrewwang
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/ndrewwang"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/22343819?v=4" alt="Avatar of soorajsunil"/>
+                    soorajsunil
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/soorajsunil"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/59295119?v=4" alt="Avatar of PatriceJada"/>
+                    PatriceJada
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/PatriceJada"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/139366515?v=4" alt="Avatar of neilsengupta-elysia"/>
+                    neilsengupta-elysia
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/neilsengupta-elysia"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/30574522?v=4" alt="Avatar of MehrdadBabazadeh"/>
+                    MehrdadBabazadeh
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/MehrdadBabazadeh"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/175809?v=4" alt="Avatar of mre"/>
+                    mre
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/mre"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/28939653?v=4" alt="Avatar of jlauber18"/>
+                    jlauber18
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/jlauber18"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/152909047?v=4" alt="Avatar of JC230903"/>
+                    JC230903
                 </div>
             <a class="sd-stretched-link" href="https://github.com/JC230903"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/143798726?v=4" alt="Avatar of Hongmeiqi"/>
+                    Hongmeiqi
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/Hongmeiqi"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/75773763?v=4" alt="Avatar of HarshvirSandhu"/>
+                    HarshvirSandhu
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/HarshvirSandhu"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/87636253?v=4" alt="Avatar of deepeshaburse"/>
+                    deepeshaburse
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/deepeshaburse"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/45606273?v=4" alt="Avatar of dc2917"/>
+                    dc2917
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/dc2917"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/26191851?v=4" alt="Avatar of aitorres"/>
+                    aitorres
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/aitorres"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/34894671?v=4" alt="Avatar of anandmy"/>
+                    anandmy
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/anandmy"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/1999462?v=4" alt="Avatar of bessman"/>
+                    bessman
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/bessman"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/119055274?v=4" alt="Avatar of abhicodes369"/>
+                    abhicodes369
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/abhicodes369"></a>
             </div>
         </div>
 </div>

--- a/static/teams/emeritus-maintainers.html
+++ b/static/teams/emeritus-maintainers.html
@@ -1,6 +1,6 @@
 
 <div class="team">
-    <h3 id="Emeritus Maintainers"class="name title">
+    <h2 id="Emeritus Maintainers"class="name title">
     Emeritus Maintainers
     </h3>
         <div class="sd-container-fluid sd-mb-4 false">
@@ -8,8 +8,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars1.githubusercontent.com/u/22661308?v=4" alt="Avatar of Scott Marquis"/>
-                    Scott Marquis
+                <img src="https://avatars.githubusercontent.com/u/22661308?v=4" alt="Avatar of Scottmar93"/>
+                    Scottmar93
                 </div>
             <a class="sd-stretched-link" href="https://github.com/Scottmar93"></a>
             </div>
@@ -18,18 +18,18 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars3.githubusercontent.com/u/13448239?v=4" alt="Avatar of Thibault Lestang"/>
-                    Thibault Lestang
+                <img src="https://avatars.githubusercontent.com/u/13448239?v=4" alt="Avatar of tlestang"/>
+                    tlestang
                 </div>
-            <a class="sd-stretched-link" href="http://tlestang.github.io"></a>
+            <a class="sd-stretched-link" href="https://github.com/tlestang"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/64051212?v=4" alt="Avatar of Priyanshu Agarwal"/>
-                    Priyanshu Agarwal
+                <img src="https://avatars.githubusercontent.com/u/64051212?v=4" alt="Avatar of priyanshuone6"/>
+                    priyanshuone6
                 </div>
             <a class="sd-stretched-link" href="https://github.com/priyanshuone6"></a>
             </div>

--- a/static/teams/gsoc-students.html
+++ b/static/teams/gsoc-students.html
@@ -1,0 +1,29 @@
+
+<div class="team">
+    <h2 id="Current Google Summer of Code students"class="name title">
+    Current Google Summer of Code students
+    </h3>
+        <div class="sd-container-fluid sd-mb-4 false">
+            <div class="sd-row sd-row-cols-2 sd-row-cols-xs-2 sd-row-cols-sm-3 sd-row-cols-md-4 sd-row-cols-lg-5 sd-g-2 sd-g-xs-2 sd-g-sm-3 sd-g-md-4 sd-g-lg-5">
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/143182673?v=4" alt="Avatar of medha-14"/>
+                    medha-14
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/medha-14"></a>
+            </div>
+        </div>
+
+        <div class="sd-col sd-d-flex-row">
+            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
+                <div class="sd-card-body">
+                <img src="https://avatars.githubusercontent.com/u/138858208?v=4" alt="Avatar of Rishab87"/>
+                    Rishab87
+                </div>
+            <a class="sd-stretched-link" href="https://github.com/Rishab87"></a>
+            </div>
+        </div>
+</div>
+        </div>
+</div>

--- a/static/teams/maintainer-trainees.html
+++ b/static/teams/maintainer-trainees.html
@@ -1,6 +1,6 @@
 
 <div class="team">
-    <h3 id="Maintainer Trainees"class="name title">
+    <h2 id="Maintainer Trainees"class="name title">
     Maintainer Trainees
     </h3>
         <div class="sd-container-fluid sd-mb-4 false">
@@ -8,8 +8,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/56610829?v=4" alt="Avatar of Andres Felipe Galvis Rodriguez"/>
-                    Andres Felipe Galvis Rodriguez
+                <img src="https://avatars.githubusercontent.com/u/56610829?v=4" alt="Avatar of Afgr1087"/>
+                    Afgr1087
                 </div>
             <a class="sd-stretched-link" href="https://github.com/Afgr1087"></a>
             </div>
@@ -18,8 +18,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/84007676?v=4" alt="Avatar of None"/>
-                    None
+                <img src="https://avatars.githubusercontent.com/u/84007676?v=4" alt="Avatar of RuiheLi"/>
+                    RuiheLi
                 </div>
             <a class="sd-stretched-link" href="https://github.com/RuiheLi"></a>
             </div>
@@ -28,8 +28,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/57876346?v=4" alt="Avatar of Smita Sahu"/>
-                    Smita Sahu
+                <img src="https://avatars.githubusercontent.com/u/57876346?v=4" alt="Avatar of smitasahu2"/>
+                    smitasahu2
                 </div>
             <a class="sd-stretched-link" href="https://github.com/smitasahu2"></a>
             </div>
@@ -38,8 +38,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/26883801?v=4" alt="Avatar of Caitlin D. Parke"/>
-                    Caitlin D. Parke
+                <img src="https://avatars.githubusercontent.com/u/26883801?v=4" alt="Avatar of parkec3"/>
+                    parkec3
                 </div>
             <a class="sd-stretched-link" href="https://github.com/parkec3"></a>
             </div>
@@ -48,8 +48,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/39382602?v=4" alt="Avatar of kawamanmi"/>
-                    kawamanmi
+                <img src="https://avatars.githubusercontent.com/u/39382602?v=4" alt="Avatar of kawaMANMI"/>
+                    kawaMANMI
                 </div>
             <a class="sd-stretched-link" href="https://github.com/kawaMANMI"></a>
             </div>
@@ -58,8 +58,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/94248626?v=4" alt="Avatar of Dharshannan Sugunan"/>
-                    Dharshannan Sugunan
+                <img src="https://avatars.githubusercontent.com/u/94248626?v=4" alt="Avatar of Dharshannan"/>
+                    Dharshannan
                 </div>
             <a class="sd-stretched-link" href="https://github.com/Dharshannan"></a>
             </div>
@@ -68,8 +68,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/98834745?v=4" alt="Avatar of Sunil Kumar Rawat"/>
-                    Sunil Kumar Rawat
+                <img src="https://avatars.githubusercontent.com/u/98834745?v=4" alt="Avatar of srawat77"/>
+                    srawat77
                 </div>
             <a class="sd-stretched-link" href="https://github.com/srawat77"></a>
             </div>
@@ -78,8 +78,8 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/168521559?v=4" alt="Avatar of Mohammed Asheruddin (Asher)"/>
-                    Mohammed Asheruddin (Asher)
+                <img src="https://avatars.githubusercontent.com/u/168521559?v=4" alt="Avatar of mohammedasher"/>
+                    mohammedasher
                 </div>
             <a class="sd-stretched-link" href="https://github.com/mohammedasher"></a>
             </div>

--- a/static/teams/past-gsoc-students.html
+++ b/static/teams/past-gsoc-students.html
@@ -1,40 +1,10 @@
 
 <div class="team">
-    <h2 id="Maintainers"class="name title">
-    Maintainers
+    <h2 id="Past Google Summer of Code students"class="name title">
+    Past Google Summer of Code students
     </h3>
         <div class="sd-container-fluid sd-mb-4 false">
             <div class="sd-row sd-row-cols-2 sd-row-cols-xs-2 sd-row-cols-sm-3 sd-row-cols-md-4 sd-row-cols-lg-5 sd-g-2 sd-g-xs-2 sd-g-sm-3 sd-g-md-4 sd-g-lg-5">
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/20817509?v=4" alt="Avatar of valentinsulzer"/>
-                    valentinsulzer
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/valentinsulzer"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/1148404?v=4" alt="Avatar of martinjrobins"/>
-                    martinjrobins
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/martinjrobins"></a>
-            </div>
-        </div>
-
-        <div class="sd-col sd-d-flex-row">
-            <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
-                <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/28443643?v=4" alt="Avatar of brosaplanella"/>
-                    brosaplanella
-                </div>
-            <a class="sd-stretched-link" href="https://github.com/brosaplanella"></a>
-            </div>
-        </div>
-
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
@@ -68,60 +38,60 @@
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/43040151?v=4" alt="Avatar of rtimms"/>
-                    rtimms
+                <img src="https://avatars.githubusercontent.com/u/64051212?v=4" alt="Avatar of priyanshuone6"/>
+                    priyanshuone6
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/rtimms"></a>
+            <a class="sd-stretched-link" href="https://github.com/priyanshuone6"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/10170302?v=4" alt="Avatar of kratman"/>
-                    kratman
+                <img src="https://avatars.githubusercontent.com/u/92637595?v=4" alt="Avatar of Vaibhav-Chopra-GT"/>
+                    Vaibhav-Chopra-GT
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/kratman"></a>
+            <a class="sd-stretched-link" href="https://github.com/Vaibhav-Chopra-GT"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/7068741?v=4" alt="Avatar of TomTranter"/>
-                    TomTranter
+                <img src="https://avatars.githubusercontent.com/u/99216956?v=4" alt="Avatar of prady0t"/>
+                    prady0t
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/TomTranter"></a>
+            <a class="sd-stretched-link" href="https://github.com/prady0t"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/48105066?v=4" alt="Avatar of aabills"/>
-                    aabills
+                <img src="https://avatars.githubusercontent.com/u/121183876?v=4" alt="Avatar of cringeyburger"/>
+                    cringeyburger
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/aabills"></a>
+            <a class="sd-stretched-link" href="https://github.com/cringeyburger"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/34451391?v=4" alt="Avatar of MarcBerliner"/>
-                    MarcBerliner
+                <img src="https://avatars.githubusercontent.com/u/52504160?v=4" alt="Avatar of santacodes"/>
+                    santacodes
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/MarcBerliner"></a>
+            <a class="sd-stretched-link" href="https://github.com/santacodes"></a>
             </div>
         </div>
 
         <div class="sd-col sd-d-flex-row">
             <div class="sd-card sd-w-100 sd-shadow-sm sd-card-hover text-center">
                 <div class="sd-card-body">
-                <img src="https://avatars.githubusercontent.com/u/42972513?v=4" alt="Avatar of DrSOKane"/>
-                    DrSOKane
+                <img src="https://avatars.githubusercontent.com/u/133691040?v=4" alt="Avatar of julian-evers"/>
+                    julian-evers
                 </div>
-            <a class="sd-stretched-link" href="https://github.com/DrSOKane"></a>
+            <a class="sd-stretched-link" href="https://github.com/julian-evers"></a>
             </div>
         </div>
 </div>

--- a/teams/GSOC-STUDENTS
+++ b/teams/GSOC-STUDENTS
@@ -1,0 +1,2 @@
+medha-14
+Rishab87

--- a/teams/PAST-GSOC-STUDENTS
+++ b/teams/PAST-GSOC-STUDENTS
@@ -1,0 +1,9 @@
+priyanshuone6
+Saransh-cpp
+Vaibhav-Chopra-GT
+agriyakhetarpal
+arjxn-py
+julian-evers
+cringeyburger
+santacodes
+prady0t


### PR DESCRIPTION
This PR includes a bunch of updates, as follows:
- Teams are rather generated via the original pagination from the GitHub API as done in #31, and are no longer generated from the all-contributors specification as previously changed in #115.
	- One drawback of this (which also existed previously) is that we can no longer display names, but rather display GitHub handle usernames (as it used to be before #260).
	- As discussed, some contributors in the all-contributors specification are lost, as they are not code contributors
- New teams for current and past GSoC students. I'm divided on this, as this is something we need to keep tracking, but at the same time I think this is fine as we will do it once per year.
- Some miscellaneous fixes and improvements:
	- bumped to a new `nox` version, which allows us to use PEP 723 metadata for scripts and several other improvements
	- use `uv` instead of `virtualenv`
	- fix headings for teams for the teams page