### PR TITLE
Remove videos

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,4 @@
 /benchmarks https://pybamm-team.github.io/pybamm-bench/ 301
 /slack https://join.slack.com/t/pybamm/shared_invite/zt-1xwnvkqrb-6ZKgB8yBU3zuzH91USdv_A 301
+/discourse https://pybamm.discourse.group/ 301
 /* /404/ 404

--- a/config.yaml
+++ b/config.yaml
@@ -154,9 +154,6 @@ params:
           - text: Get involved
             link: /contribute/
 
-          - text: Training
-            link: /training/
-
           - text: Ionworks
             link: https://ionworks.com/
 

--- a/content/learn.md
+++ b/content/learn.md
@@ -44,10 +44,6 @@ If you would like to get started with PyBaMM, you may go through the [Getting St
 
 For more resources, please refer to the [Examples section](https://docs.pybamm.org/en/stable/source/examples/index.html) in the PyBaMM documentation.
 
-## Video tutorials
-
-We regularly hold PyBaMM workshops. You can find a list of the workshops we have held with links to the corresponding recordings on the [Training](/training/) page.
-
 ## Get help
 
-You can get help by posting questions on the [PyBaMM Slack channels](https://pybamm.org/slack/) or preferably in [GitHub discussions](https://github.com/pybamm-team/PyBaMM/discussions). You can also get paid support from [Ionworks](https://ionworks.com/).
+You can get help from the community by posting questions on the [PyBaMM Discourse](https://pybamm.org/discourse/).

--- a/content/learn.md
+++ b/content/learn.md
@@ -46,4 +46,4 @@ For more resources, please refer to the [Examples section](https://docs.pybamm.o
 
 ## Get help
 
-You can get help from the community by posting questions on the [PyBaMM Discourse](https://pybamm.org/discourse/).
+You can get help from the community by posting questions on the [PyBaMM Discourse](https://pybamm.discourse.group/).


### PR DESCRIPTION
Remove links to outdated videos (I left the page for now, but removed any links to it).

I have also updated the "Get help" section. @valentinsulzer, I removed the mention to IW as I thought it was no longer applicable, but let me know if I should bring it back.