### PR TITLE
Mirror release policy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,6 +87,8 @@ params:
           url: /code-of-conduct/
         - title: Roadmap
           url: /roadmap/
+        - title: Release Policy
+          url: /release-policy/
         - title: Open-Source Programs
           url: /open-source-programs/
 

--- a/content/release-policy.md
+++ b/content/release-policy.md
@@ -1,0 +1,10 @@
+---
+title: Release Policy
+summary: This page describes the PyBaMM Code of Conduct for all project participants and contributors.
+---
+
+<!-- This page is a placeholder for the Release Policy, which is stored in the main PyBaMM repository
+on GitHub. The content of this page is automatically updated when the file in the repository is changed.
+The title MUST be present in the frontmatter, since Hugo has to use it at build time, not runtime. -->
+
+{{< external-content-simple "https://rawcdn.githack.com/pybamm-team/PyBaMM/refs/heads/main/RELEASE.md" >}}

--- a/content/release-policy.md
+++ b/content/release-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Release Policy
-summary: This page describes the PyBaMM Code of Conduct for all project participants and contributors.
+summary: This page describes PyBaMM's release policy.
 ---
 
 <!-- This page is a placeholder for the Release Policy, which is stored in the main PyBaMM repository


### PR DESCRIPTION
Adding a page to mirror the release policy which, like the code of conduct, lives in the Github repo.